### PR TITLE
[46기 조혜진] Add : Footer UI 추가

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -7,6 +7,7 @@ const Footer = () => {
   return (
     <div className="footer">
       <img
+        className="logo"
         src="./images/Footer/gron-symbol-white.png"
         alt="gron-logo-white"
         onClick={() => navigate('/')}

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,7 +1,19 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import './Footer.scss';
 
 const Footer = () => {
-  return <div>Footer</div>;
+  const navigate = useNavigate();
+  return (
+    <div className="footer">
+      <img
+        src="./images/Footer/gron-symbol-white.png"
+        alt="gron-logo-white"
+        onClick={() => navigate('/')}
+      />
+      <div className="copyright">© 2023 grön</div>
+    </div>
+  );
 };
 
 export default Footer;

--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -1,1 +1,22 @@
-//q
+@import '../../styles/mixin';
+@import '../../styles/variables';
+
+.footer {
+  @include flexCenter;
+  flex-direction: column;
+  height: 130px;
+  background-color: #111111;
+
+  img {
+    width: 30px;
+    margin-bottom: 10px;
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  .copyright {
+    @include textStyle(20px, 200);
+    color: $secondary-color;
+  }
+} //q

--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -7,7 +7,7 @@
   height: 130px;
   background-color: #111111;
 
-  img {
+  .logo {
     width: 30px;
     margin-bottom: 10px;
     &:hover {
@@ -19,4 +19,4 @@
     @include textStyle(20px, 200);
     color: $secondary-color;
   }
-} //q
+}


### PR DESCRIPTION
## 1. 본 PR이 서비스에 기여하는 기능적 측면 
- Footer 컴포넌트가 모든 페이지 최상단에 노출되게끔 했습니다. Footer 내 배치한 서비스 로고를 클릭하면 메인 화면으로 이동할 수 있습니다.

## 2. 본 PR Merge시 유저 관점에서 기대효과

- 모든 페이지 하단에 일관된 브랜딩을 적용하여 유저가 서비스를 이용할 때 통일성을 느낄 수 있습니다. 

## 3. 이 브랜치에서 개발한 내용

> Footer UI 추가


## 4. 개발한 화면 스크린샷
<img width="720" alt="Screenshot 2023-05-31 at 10 34 43" src="https://github.com/wecode-bootcamp-korea/46-1st-BestFriend-frontend/assets/123653529/860050dc-77bb-42b1-baff-b5ecb1b514ad">

## 5. 본 브랜치에서 경험한 성장포인트
- 모든 페이지에 사용되는 컴포넌트이기 때문에 빠르게 Merge시켜야 한다고 판단하여 우선순위 높게 작업했습니다. 팀원들과 기능을 나눠 레이아웃을 구성하고 있기 때문에 내가 작업하는 영역이 서비스 전반, 그리고 팀원들의 작업에 어떤 영향을 미치는지 생각하며 작업을 진행했습니다.