### PR TITLE
[46기 이재웅] Add : 장바구니 비어있을때 UI 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.9.0",
         "react-router-dom": "^6.11.2",
         "react-scripts": "5.0.1",
         "sass": "^1.62.1",
@@ -15009,6 +15010,14 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-icons": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.9.0.tgz",
+      "integrity": "sha512-ijUnFr//ycebOqujtqtV9PFS7JjhWg0QU6ykURVHuL4cbofvRCf3f6GMn9+fBktEFQOIVZnuAYLZdiyadRQRFg==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.9.0",
     "react-router-dom": "^6.11.2",
     "react-scripts": "5.0.1",
     "sass": "^1.62.1",

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { AiFillWarning } from 'react-icons/ai';
 import CartBox from './component/CartBox';
 import './Cart.scss';
 
@@ -59,6 +60,14 @@ const Cart = () => {
               />
             );
           })} */}
+          {cartList.length === 0 && (
+            <div className="cart-warning">
+              <div>
+                <AiFillWarning className="warning-icon" />
+                <p>장바구니가 비어 있습니다.</p>
+              </div>
+            </div>
+          )}
           {cartList.map(product => {
             return (
               <CartBox

--- a/src/pages/Cart/Cart.scss
+++ b/src/pages/Cart/Cart.scss
@@ -21,6 +21,16 @@
     margin-right: 40px;
   }
 
+  .cart-warning {
+    margin-top: 110px;
+    text-align: center;
+  }
+
+  .warning-icon {
+    color: lightgray;
+    font-size: 150px;
+  }
+
   .cart-aside {
     width: 40%;
     padding-top: 25px;

--- a/src/pages/Cart/component/CartBox.js
+++ b/src/pages/Cart/component/CartBox.js
@@ -70,12 +70,7 @@ const CartBox = ({ product, getCart }) => {
         <div className="content">
           <h1>{name}</h1>
           <div className="count">
-            <button
-              className="btn btn-box"
-              onClick={() => {
-                handleCountMinus();
-              }}
-            >
+            <button className="btn btn-box" onClick={handleCountMinus}>
               <img
                 src="/images/ProductDetail/arrow-down.png"
                 alt=""
@@ -83,12 +78,7 @@ const CartBox = ({ product, getCart }) => {
               />
             </button>
             <p className="content-text">수량 : {quantity}개</p>
-            <button
-              className="btn btn-box"
-              onClick={() => {
-                handleCountUp();
-              }}
-            >
+            <button className="btn btn-box" onClick={handleCountUp}>
               <img
                 src="/images/ProductDetail/arrow-up.png"
                 alt=""
@@ -97,12 +87,7 @@ const CartBox = ({ product, getCart }) => {
             </button>
           </div>
           <div />
-          <button
-            className="btn"
-            onClick={() => {
-              handleDelete();
-            }}
-          >
+          <button className="btn" onClick={handleDelete}>
             삭제
           </button>
         </div>


### PR DESCRIPTION
## 1. 본 PR이 우리 팀의 웹 서비스 제품성에 어떠한 기여를 하였고, 사용자에게 어떠한 기대효과를 전달하는지 작성해주세요.
- 내 PR이 제품 내 어떠한 기능적인 배경/전후맥락 가운데 개발되었나요?

고객이 결제 전 제품에대한 가격,수량 등을 확인하는 페이지로써 유저의 편의를위해 장바구니가 비어있을 때 알리기위해 장바구니가 비어있다는 경고메세지를 전달 받습니다.

- 내 PR이 Merge 됨으로써 유저에게 전달되는 편익/기대효과는 무엇일까요?

장바구니가 비어있는것을 빠르게 확인할 수 있어 웹 사용이 편리해진다.



<br />

## 2. 이 브랜치에서 어떤 내용을 개발했는지 큰 제목과 그리고 상세 내역을 적어주세요.

## 장바구니 비어있을때 알림

- 받아온 상품 배열 길이가 0 일때만 알람창 띄우기

<br />

## 3. 개발한 화면을 캡쳐해서 첨부 해 주세요. (drag & drop 또는 첨부파일 추가)
<br />

-
<img width="1501" alt="스크린샷 2023-06-07 오전 10 47 16" src="https://github.com/wecode-bootcamp-korea/46-1st-BestFriend-frontend/assets/123567359/709e8701-9ff8-4f2b-b075-8948e6ddc1a3">

<br />

## 4. 이 브랜치에서 개발하면서 느꼇던 개발 성장포인트를 적어주세요.

- 조건부 랜더링 && 을 사용하며 코드의 가독성이 좋아지는것을 느꼈다.
